### PR TITLE
Add a README to point to static-kas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+A web app to launch on-demand instances of https://github.com/alvaroaleman/static-kas given Prow job URLs or links to must-gather archives


### PR DESCRIPTION
Since https://github.com/vrutkovs/kaas shows up first on Google
when searching static kas it's nice to have a link here