### PR TITLE
Revert "Don't generate app label until later"

### DIFF
--- a/pkg/kaas/websocket.go
+++ b/pkg/kaas/websocket.go
@@ -126,6 +126,10 @@ func (s *ServerSettings) removeKAS(conn *websocket.Conn, appName string) {
 }
 
 func (s *ServerSettings) newKAS(conn *websocket.Conn, rawURL string) {
+	// Generate a unique app label
+	appLabel := generateAppLabel()
+	sendWSMessage(conn, "app-label", appLabel)
+
 	// Fetch must-gather.tar path if prow URL specified
 	prowInfo, err := getTarPaths(conn, rawURL)
 	if err != nil {
@@ -146,10 +150,6 @@ func (s *ServerSettings) newKAS(conn *websocket.Conn, rawURL string) {
 		sendWSMessage(conn, "choose", string(data))
 		return
 	}
-
-	// Generate a unique app label
-	appLabel := generateAppLabel()
-	sendWSMessage(conn, "app-label", appLabel)
 
 	dumpURL := prowInfo.ClusterDumpURLs[0]
 


### PR DESCRIPTION
Reverts vrutkovs/kaas#5

I'm sorry I didn't test this, I figured it was a small enough change but it didn't work 🤦🏻 

"Generate" button no longer works.

https://kaas.dptools.openshift.org/?search=https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/40481/rehearse-40481-periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-aws-ovn/1671181230051168256
